### PR TITLE
Update README, `dexdump` is now required

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Install dependencies:
 ```
 pip install -r requirements.txt
 ```
+
+εxodus core requires dexdump:
+```
+sudo apt install dexdump
+```
+
 Run tests:
 ```
 python -m unittest discover -s exodus_core -p "test_*.py"


### PR DESCRIPTION
Now that dexdump is found in the PATH, it is a good idea to add a line for it in the installation process.