### PR TITLE
Remove the number of libraries.

### DIFF
--- a/exodus_core/analysis/static_analysis.py
+++ b/exodus_core/analysis/static_analysis.py
@@ -480,7 +480,7 @@ class StaticAnalysis:
         print('- App permissions: %s' % len(permissions))
         for p in permissions:
             print('    - %s' % p)
-        print('- App libraries: %s' % len(libraries))
+        print('- App libraries:')
         for l in libraries:
             print('    - %s' % l)
         print('- Certificates: %s' % len(certificates))


### PR DESCRIPTION
This information is useless and breaks compatibility between python<3.7
and python3.7

Fixes #10