### PR TITLE
Wait until icon download is complete to check if file exists

### DIFF
--- a/exodus_core/analysis/static_analysis.py
+++ b/exodus_core/analysis/static_analysis.py
@@ -299,8 +299,8 @@ class StaticAnalysis:
                     f = requests.get(i.get('url'))
                     with open(path, mode='wb') as fp:
                         fp.write(f.content)
-                        if os.path.isfile(path) and os.path.getsize(path) > 0:
-                            return path
+                    if os.path.isfile(path) and os.path.getsize(path) > 0:
+                        return path
 
         raise FileNotFoundError('Unable to download the icon from details')
 
@@ -323,8 +323,8 @@ class StaticAnalysis:
             f = requests.get(icon_url)
             with open(path, mode='wb') as fp:
                 fp.write(f.content)
-                if os.path.isfile(path) and os.path.getsize(path) > 0:
-                    return path
+            if os.path.isfile(path) and os.path.getsize(path) > 0:
+                return path
         else:
             raise FileNotFoundError('Unable to download the icon from GPlay')
 


### PR DESCRIPTION
This solves an issue with exodus with applications such as `com.backmarket`
It also seems more logical to me anyway :)