### PR TITLE
Rework get_embedded_classes

### DIFF
--- a/exodus_core/analysis/static_analysis.py
+++ b/exodus_core/analysis/static_analysis.py
@@ -148,7 +148,7 @@ class StaticAnalysis:
         :return: set of Java classes names as string
         """
         if depth > 10:  # zipbomb protection
-            logging.error('max recursion depth in zip file reached: %s' % apkfile)
+            logging.error(f'Max recursion depth in zip file reached: {apkfile}')
             return set()
 
         apk_regex = re.compile(r'.*\.apk')
@@ -165,10 +165,10 @@ class StaticAnalysis:
 
                     elif class_regex.search(info.filename):
                         apk_zip.extract(info, tmp_dir)
-                        run = subprocess.check_output(['dexdump', '{}/{}'.format(tmp_dir, info.filename)])
+                        run = subprocess.check_output(['dexdump', f'{tmp_dir}/{info.filename}'])
                         classes = classes.union(set(re.findall(r'[A-Z]+((?:\w+\/)+\w+)', run.decode(errors='ignore'))))
         except zipfile.BadZipFile as ex:
-            logging.error('Unable to decode {}'.format(apkfile))
+            logging.error(f'Unable to decode {apkfile}')
             raise Exception('Unable to decode the APK') from ex
 
         return classes

--- a/exodus_core/analysis/static_analysis.py
+++ b/exodus_core/analysis/static_analysis.py
@@ -43,23 +43,6 @@ def get_td_url():
     return DEFAULT
 
 
-def which(program):
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-    return None
-
-
 def get_details_from_gplaycli(handle):
     """
     Get the details from gpc like creator, number of downloads, etc
@@ -157,35 +140,44 @@ class StaticAnalysis:
         if self.apk is None:
             self.apk = APK(self.apk_path)
 
+    @staticmethod
+    def _get_embedded_classes(apkfile, depth=0):
+        """
+        Get the list of Java classes embedded into all DEX files.
+
+        :return: set of Java classes names as string
+        """
+        if depth > 10:  # zipbomb protection
+            logging.error('max recursion depth in zip file reached: %s' % apkfile)
+            return set()
+
+        apk_regex = re.compile(r'.*\.apk')
+        class_regex = re.compile(r'classes.*\.dex')
+        classes = set()
+
+        with TemporaryDirectory() as tmp_dir, zipfile.ZipFile(apkfile, 'r') as apk_zip:
+            for info in apk_zip.infolist():
+                # apk files can contain apk files, again
+                if apk_regex.search(info.filename):
+                    with apk_zip.open(info) as apk_fp:
+                        classes = classes.union(StaticAnalysis._get_embedded_classes(apk_fp, depth + 1))
+
+                elif class_regex.search(info.filename):
+                    apk_zip.extract(info, tmp_dir)
+                    run = subprocess.check_output(['dexdump', '{}/{}'.format(tmp_dir, info.filename)])
+                    classes = classes.union(set(re.findall(r'[A-Z]+((?:\w+\/)+\w+)', run.decode(errors='ignore'))))
+
+        return classes
+
     def get_embedded_classes(self):
         """
         Get the list of Java classes embedded into all DEX files.
         :return: array of Java classes names as string
         """
-        if self.classes is not None:
-            return self.classes
+        if self.classes is None:
+            self.classes = list(self._get_embedded_classes(self.apk_path))
 
-        class_regex = re.compile(r'classes.*\.dex')
-        with TemporaryDirectory() as tmp_dir:
-            with zipfile.ZipFile(self.apk_path, "r") as apk_zip:
-                class_infos = (info for info in apk_zip.infolist() if class_regex.search(info.filename))
-                for info in class_infos:
-                    apk_zip.extract(info, tmp_dir)
-            dexdump = which('dexdump')
-            cmd = '{} {}/classes*.dex | perl -n -e\'/[A-Z]+((?:\w+\/)+\w+)/ && print "$1\n"\'|sort|uniq'.format(
-                dexdump, tmp_dir)
-            try:
-                self.classes = subprocess.check_output(
-                    cmd,
-                    stderr=subprocess.STDOUT,
-                    shell=True,
-                    universal_newlines=True
-                ).splitlines()
-                logging.debug('{} classes found in {}'.format(len(self.classes), self.apk_path))
-                return self.classes
-            except subprocess.CalledProcessError:
-                logging.error('Unable to decode {}'.format(self.apk_path))
-                raise Exception('Unable to decode the APK')
+        return self.classes
 
     def detect_trackers_in_list(self, class_list):
         """

--- a/exodus_core/analysis/test_exodus_analyze.py
+++ b/exodus_core/analysis/test_exodus_analyze.py
@@ -100,10 +100,10 @@ class TestExodus(unittest.TestCase):
 
     def test_list_classes(self):
         apps = [
-            {'name': 'braiar', 'nb_classes': 3882},
-            {'name': 'whatsapp', 'nb_classes': 5429},
-            {'name': 'hsbc', 'nb_classes': 7431},
-            {'name': 'instapaper', 'nb_classes': 2650},
+            {'name': 'braiar', 'nb_classes': 3896},
+            {'name': 'whatsapp', 'nb_classes': 5457},
+            {'name': 'hsbc', 'nb_classes': 7481},
+            {'name': 'instapaper', 'nb_classes': 2676},
         ]
         for app in apps:
             with self.subTest(app=app['name']):


### PR DESCRIPTION
- Support embedded apk files as found by apkeep.
- Drop usage of perl, sort, uniq and subprocess shell (security issue).
- Drop which() (already done by subprocess).
- Ignore invalid utf-8 encoding from dexdump.
- Support multiple dex files with the same name in the apk.
- Separate caching logic from extraction logic to allow recursive call.