### PR TITLE
chore: Do not require dexdump to install package

### DIFF
--- a/exodus_core/analysis/static_analysis.py
+++ b/exodus_core/analysis/static_analysis.py
@@ -21,6 +21,23 @@ from PIL import Image
 PHASH_SIZE = 8
 
 
+def which(program):
+    def is_exe(fpath):
+        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+    fpath, fname = os.path.split(program)
+    if fpath:
+        if is_exe(program):
+            return program
+    else:
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path, program)
+            if is_exe(exe_file):
+                return exe_file
+
+    return None
+
+
 def get_td_url():
     DEFAULT = "https://matlink.fr/token/email/gsfid"
     cred_paths_list = [
@@ -164,6 +181,11 @@ class StaticAnalysis:
                             classes = classes.union(StaticAnalysis._get_embedded_classes(apk_fp, depth + 1))
 
                     elif class_regex.search(info.filename):
+                        if which('dexdump') is None:
+                            logging.error("Unable to find dexdump executable, please install it.")
+                            logging.error("On Debian-like OS, run sudo apt-get install dexdump")
+                            sys.exit(1)
+
                         apk_zip.extract(info, tmp_dir)
                         run = subprocess.check_output(['dexdump', f'{tmp_dir}/{info.filename}'])
                         classes = classes.union(set(re.findall(r'[A-Z]+((?:\w+\/)+\w+)', run.decode(errors='ignore'))))

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,8 @@
 #!/usr/bin/env python
 
-import os
 import sys
 
 from setuptools import setup, find_packages
-
-
-def which(program):
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-    return None
 
 
 if sys.version_info.major == 3 and sys.version_info.minor < 3:
@@ -29,11 +11,6 @@ if sys.version_info.major == 3 and sys.version_info.minor < 3:
 
 if sys.platform == 'darwin' or sys.platform == 'win32':
     print("Unfortunately, we do not support your platform %s" % sys.platform)
-    sys.exit(1)
-
-if which('dexdump') is None:
-    print("Unable to find dexdump executable, please install it.")
-    print("On Debian-like OS, run sudo apt-get install dexdump")
     sys.exit(1)
 
 install_requires = [


### PR DESCRIPTION
Remove `dexdump` presence check during package installation because, if you have `exodus-core` in your requirements, it prevents to:

* install requirements and run tests/lints/etc (workaround: install dexdump even if you don't need it :shrug:)
* install requirements to upgrade them for Dependabot for instance (workaround: none :-1:)