### PR TITLE
chore: Bump androguard from 3.3.5 to 4.1.0

### DIFF
--- a/exodus_core/analysis/static_analysis.py
+++ b/exodus_core/analysis/static_analysis.py
@@ -4,21 +4,24 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import zipfile
 from collections import namedtuple
-from future.moves import sys
 from hashlib import sha256, sha1
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import dhash
 import requests
 import six
-from androguard.core.bytecodes import axml
-from androguard.core.bytecodes.apk import APK
+from androguard.core import axml
+from androguard.core.apk import APK
+from androguard.util import set_log
 from cryptography.x509.name import ObjectIdentifier, _NAMEOID_DEFAULT_TYPE, _ASN1Type, NameAttribute
 from PIL import Image
 
 PHASH_SIZE = 8
+
+set_log("INFO")
 
 
 def which(program):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-androguard==3.3.5
+androguard==4.0.2
 cryptography==42.0.4
 dhash==1.4
 jellyfish==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-androguard==4.0.2
+androguard==4.1.0
 cryptography==42.0.4
 dhash==1.4
 jellyfish==0.5.6

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.platform == 'darwin' or sys.platform == 'win32':
     sys.exit(1)
 
 install_requires = [
-    'androguard==4.0.2',
+    'androguard==4.1.0',
     'cryptography==42.0.4',
     'dhash==1.4',
     'jellyfish==0.5.6',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.platform == 'darwin' or sys.platform == 'win32':
     sys.exit(1)
 
 install_requires = [
-    'androguard==3.3.5',
+    'androguard==4.0.2',
     'cryptography==42.0.4',
     'dhash==1.4',
     'jellyfish==0.5.6',


### PR DESCRIPTION
Tested with my local instance, seems to work as expected.